### PR TITLE
switch some console.errors to console.warn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 **.env
+**node_modules
+**yarn-error.log
+**yarn.lock
+**package-lock.json
+**package.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 **yarn-error.log
 **yarn.lock
 **package-lock.json
-**package.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
 **.env
 **node_modules
-**yarn-error.log
-**yarn.lock
-**package-lock.json

--- a/index.js
+++ b/index.js
@@ -13,8 +13,7 @@ const installDependencies = () => {
         }
 
         if (stderr) {
-            console.error(`stderr: ${stderr}`);
-            return;
+            console.warn(`stderr: ${stderr}`);
         }
 
         console.log("Packages installed successfully:\n", stdout);
@@ -31,7 +30,7 @@ try {
     installDependencies();
 }
 
-require('dotenv').config({path:'.env'});
+require('dotenv').config({ path: '.env' });
 const fs = require('fs');
 const path = require('path');
 const { 


### PR DESCRIPTION
some things that are simply warnings and not full on errors have been replaced with `console.warn` instead of `console.error`

this change also includes 1 `.gitignore` thing i forgot
